### PR TITLE
Removed unnecessary italics around newspaper quotes.

### DIFF
--- a/src/epub/css/local.css
+++ b/src/epub/css/local.css
@@ -118,10 +118,6 @@ section[epub|type~="dedication"] p{
 	text-indent: 0;
 }
 
-i > i{
-	font-style: normal;
-}
-
 span[epub|type~="subtitle"]{
 	display: block;
 	font-weight: normal;

--- a/src/epub/text/between-the-scenes-3.xhtml
+++ b/src/epub/text/between-the-scenes-3.xhtml
@@ -15,11 +15,9 @@
 		<section id="chapter-6-1" epub:type="chapter">
 			<h3 epub:type="title">
 				<span epub:type="z3998:roman">I</span>
-				<span epub:type="subtitle">Extract from the Advertising Columns of “<span epub:type="se:name.publication.newspaper">The Times</span>.”</span>
+				<span epub:type="subtitle">Extract from the Advertising Columns of <i epub:type="se:name.publication.newspaper">The Times</i>.</span>
 			</h3>
-			<p>
-				<i><span epub:type="z3998:recipient">An Unknown Friend</span> is requested to mention (by advertisement) an address at which a letter can reach him. The receipt of the information which he offers will be acknowledged by a reward of Five Pounds.</i>
-			</p>
+			<p><span epub:type="z3998:recipient">An Unknown Friend</span> is requested to mention (by advertisement) an address at which a letter can reach him. The receipt of the information which he offers will be acknowledged by a reward of Five Pounds.</p>
 		</section>
 		<section id="chapter-6-2" epub:type="chapter">
 			<h3 epub:type="title">
@@ -235,14 +233,10 @@
 		<section id="chapter-6-13" epub:type="chapter">
 			<h3 epub:type="title">
 				<span epub:type="z3998:roman">XIII</span>
-				<span epub:type="subtitle">Extract from the “East Suffolk Argus.”</span>
+				<span epub:type="subtitle">Extract from the <i epub:type="se:name.publication.newspaper">East Suffolk Argus</i>.</span>
 			</h3>
-			<p>
-				<i><b>Aldborough</b>.⁠—We notice with pleasure the arrival of visitors to this healthful and far-famed watering-place earlier in the season than usual during the present year. <i xml:lang="la">Esto Perpetua</i> is all we have to say.</i>
-			</p>
-			<p>
-				<i><b>Visitors’ List</b>.⁠—Arrivals since our last. North Shingles Villa⁠—<abbr>Mrs.</abbr> Bygrave; Miss Bygrave.</i>
-			</p>
+			<p><b>Aldborough</b>.⁠—We notice with pleasure the arrival of visitors to this healthful and far-famed watering-place earlier in the season than usual during the present year. <i xml:lang="la">Esto Perpetua</i> is all we have to say.</p>
+			<p><b>Visitors’ List</b>.⁠—Arrivals since our last. North Shingles Villa⁠—<abbr>Mrs.</abbr> Bygrave; Miss Bygrave.</p>
 		</section>
 	</body>
 </html>


### PR DESCRIPTION
Fixed up some non-semantic italics around newspaper extracts, and corrected tagging of newspaper titles. Removed unneeded CSS designed to style nested italics.